### PR TITLE
feat: add hookArg support to createModel

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -36,7 +36,7 @@ npm install --save hox
 > 注意：作为 model 的 custom Hook 不能接收参数，因为该 Hook 是全局的，不会随着函数每次执行而执行，只会在初始化的时候执行，或者手动触发执行。
 
 ```jsx
-import { useState } from 'React';
+import { useState } from "React";
 import { createModel } from "hox";
 
 function useCounter() {
@@ -76,6 +76,31 @@ function App(props) {
 `useCounterModel` 是一个真正的 Hook，会订阅数据的更新。也就是说，当点击 "Increment" 按钮时，会触发 counter model 的更新，并且最终通知所有使用 `useCounterModel` 的组件或 Hook。
 
 ## 进阶用法
+
+### 为 custom hook 提供参数
+
+当一个 custom hook 被用于不同的场景下，我们希望它们可以拥有不同的参数。
+
+如下方的例子一样，我们可以使用 `createModel` 的第二个参数，为 custom hook 设置 Props。这是设置初始值的最佳时机。
+
+```jsx
+import { useState } from "React";
+import { createModel } from "hox";
+
+function useCounter(initialValue) {
+  const [count, setCount] = useState(initialValue ?? 0);
+  const decrement = () => setCount(count - 1);
+  const increment = () => setCount(count + 1);
+  return {
+    count,
+    decrement,
+    increment
+  };
+}
+
+const useCounterModel = createModel(useCounter);
+const useCounterModelWithInitialValue = createModel(useCounter, 20);
+```
 
 ### model 之间的依赖
 
@@ -223,13 +248,16 @@ type ModelMap = {
 
 ```js
 // 订阅单个 model
-export default withModel(useCounterModel, (counter) => ({
+export default withModel(useCounterModel, counter => ({
   count: counter.count
-}))(App)
+}))(App);
 
 // 订阅多个 model
-export default withModel([useCounterModel, useTimerModel], ([counter, timer]) => ({
-  count: counter.count,
-  timer,
-}))(App)
+export default withModel(
+  [useCounterModel, useTimerModel],
+  ([counter, timer]) => ({
+    count: counter.count,
+    timer
+  })
+)(App);
 ```

--- a/README-cn.md
+++ b/README-cn.md
@@ -192,7 +192,7 @@ const counter = useCounterModel(model => [model.count, model.x.y]);
 ### createModel
 
 ```typescript
-declare function createModel(hook: ModelHook): UseModel;
+declare function createModel(hook: ModelHook, hookArg?): UseModel;
 ```
 
 创建一个 model 。
@@ -206,6 +206,8 @@ const useCounterModelA = createModel(useCounter);
 const useCounterModelB = createModel(useCounter);
 const useTimerModel = createModel(useTimer);
 ```
+
+也可以通过第二个参数[给 custom hook 传参](#给-custom-hook-传参)。
 
 > 两次调用 `createModel(useCounter)` 会创建 model 的两个实例，彼此相互隔离。
 

--- a/README-cn.md
+++ b/README-cn.md
@@ -77,11 +77,11 @@ function App(props) {
 
 ## 进阶用法
 
-### 为 custom hook 提供参数
+### 给 custom hook 传参
 
 当一个 custom hook 被用于不同的场景下，我们希望它们可以拥有不同的参数。
 
-如下方的例子一样，我们可以使用 `createModel` 的第二个参数，为 custom hook 设置 Props。这是设置初始值的最佳时机。
+如下方的例子一样，我们可以通过 `createModel` 的第二个参数，为 custom hook 设置一个参数。这是设置初始值的最佳时机。
 
 ```jsx
 import { useState } from "React";

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ function App(props) {
 
 ### Pass props to custom hooks
 
-Under certain circumstances, we might want to pass props to custom hooks.
+In some scenarios, we might want to pass props to custom hooks.
 
-Just like the example below, we could pass a second parameter to createModel to set Props for the custom hook. This is the best time to set the initial value.
+Just like the example below, we could pass props to the second parameter of createModel to set props for the custom hook. This is the best time to set the initial value.
 
 ```jsx
 import { useState } from "React";

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ function App(props) {
 
 ## Advanced Usages
 
-### Pass a value to custom hooks
+### Pass values to custom hooks
 
-In some scenarios, we might want to pass a value to custom hooks.
+In some scenarios, we might want to pass values to custom hooks.
 
-Just like the example below, we could pass a value to the second parameter of createModel for the custom hook. This is the best time to set the initial value.
+Just like the example below, we could pass a value to the second parameter of createModel for the custom hook. This is the best time to set the initial value for `useState`, etc.
 
 ```jsx
 import { useState } from "React";
@@ -190,7 +190,7 @@ In addition, we recommend splitting a large model into small parts, so that not 
 ### createModel
 
 ```typescript
-declare function createModel(hook: ModelHook): UseModel;
+declare function createModel(hook: ModelHook, hookArg?): UseModel;
 ```
 
 Create a model.
@@ -204,6 +204,8 @@ const useCounterModelA = createModel(useCounter);
 const useCounterModelB = createModel(useCounter);
 const useTimerModel = createModel(useTimer);
 ```
+
+You can also [pass values to custom hooks](#Pass-values-to-custom-hooks) to the second parameter of createModels for custom hooks.
 
 > Calling `createModel(useCounter)` two times will create two instances which are isolated from each other.
 

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ function App(props) {
 
 ## Advanced Usages
 
-### Pass props to custom hooks
+### Pass a value to custom hooks
 
-In some scenarios, we might want to pass props to custom hooks.
+In some scenarios, we might want to pass a value to custom hooks.
 
-Just like the example below, we could pass props to the second parameter of createModel to set props for the custom hook. This is the best time to set the initial value.
+Just like the example below, we could pass a value to the second parameter of createModel for the custom hook. This is the best time to set the initial value.
 
 ```jsx
 import { useState } from "React";

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In hox, you can process a custom Hook with `createModel` to make it persistent a
 > Attention: The custom Hook you pass to `createModel` can not have parameters.
 
 ```jsx
-import { useState } from 'React';
+import { useState } from "React";
 import { createModel } from "hox";
 
 function useCounter() {
@@ -77,6 +77,31 @@ function App(props) {
 
 ## Advanced Usages
 
+### Pass props to custom hooks
+
+Under certain circumstances, we might want to pass props to custom hooks.
+
+Just like the example below, we could pass a second parameter to createModel to set Props for the custom hook. This is the best time to set the initial value.
+
+```jsx
+import { useState } from "React";
+import { createModel } from "hox";
+
+function useCounter(initialValue) {
+  const [count, setCount] = useState(initialValue ?? 0);
+  const decrement = () => setCount(count - 1);
+  const increment = () => setCount(count + 1);
+  return {
+    count,
+    decrement,
+    increment
+  };
+}
+
+const useCounterModel = createModel(useCounter);
+const useCounterModelWithInitialValue = createModel(useCounter, 20);
+```
+
 ### Dependencies between models
 
 Although you can still design your model according to the traditional single data source pattern, we recommend splitting the big model into small parts. Therefore inevitably, we need to handle dependencies between multiple models. For example, the `order` model depends on the `account` model.
@@ -97,27 +122,28 @@ export function useCounterDouble() {
 }
 ```
 
-### Readonly	
+### Readonly
 
-In some scenarios, we only want to read the current value of a model, without subscribing to its updates.	
+In some scenarios, we only want to read the current value of a model, without subscribing to its updates.
 
-Just like the example below, we can read the current value of counter model from `useCounterModel.data`.	
+Just like the example below, we can read the current value of counter model from `useCounterModel.data`.
 
-> `useCounterModel.data` is not Hook, you can use it anywhere.	
-```jsx	
-import { useState } from "React";	
-import { useCounterModel } from "./counter";	
-export function logger() {	
-  const [log, setLog] = useState([]);	
-  const logCount = () => {	
-    const counter = useCounterModel.data;	
-    setLog(log.concat(counter));	
-  };	
-  return {	
-    log,	
-    logCount	
-  };	
-}	
+> `useCounterModel.data` is not Hook, you can use it anywhere.
+
+```jsx
+import { useState } from "React";
+import { useCounterModel } from "./counter";
+export function logger() {
+  const [log, setLog] = useState([]);
+  const logCount = () => {
+    const counter = useCounterModel.data;
+    setLog(log.concat(counter));
+  };
+  return {
+    log,
+    logCount
+  };
+}
 ```
 
 ### How to use hox in class components
@@ -220,13 +246,16 @@ For example:
 
 ```js
 // subscibe to a single model
-export default withModel(useCounterModel, (counter) => ({
+export default withModel(useCounterModel, counter => ({
   count: counter.count
-}))(App)
+}))(App);
 
 // subscribe to multiple models
-export default withModel([useCounterModel, useTimerModel], ([counter, timer]) => ({
-  count: counter.count,
-  timer,
-}))(App)
+export default withModel(
+  [useCounterModel, useTimerModel],
+  ([counter, timer]) => ({
+    count: counter.count,
+    timer
+  })
+)(App);
 ```

--- a/src/__tests__/__snapshots__/main.test.tsx.snap
+++ b/src/__tests__/__snapshots__/main.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`simple 1`] = `
+exports[`createModel with arg 1`] = `
 <DocumentFragment>
   <div>
     <button>
@@ -9,8 +9,34 @@ exports[`simple 1`] = `
     <p>
       5
     </p>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`createModel with arg 2`] = `
+<DocumentFragment>
+  <div>
+    <button>
+      Change
+    </button>
     <p>
-      5
+      6
+    </p>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`simple 1`] = `
+<DocumentFragment>
+  <div>
+    <button>
+      Change
+    </button>
+    <p>
+      0
+    </p>
+    <p>
+      0
     </p>
   </div>
 </DocumentFragment>
@@ -23,10 +49,10 @@ exports[`simple 2`] = `
       Change
     </button>
     <p>
-      6
+      1
     </p>
     <p>
-      6
+      1
     </p>
   </div>
 </DocumentFragment>

--- a/src/__tests__/__snapshots__/main.test.tsx.snap
+++ b/src/__tests__/__snapshots__/main.test.tsx.snap
@@ -7,10 +7,10 @@ exports[`simple 1`] = `
       Change
     </button>
     <p>
-      0
+      5
     </p>
     <p>
-      0
+      5
     </p>
   </div>
 </DocumentFragment>
@@ -23,10 +23,10 @@ exports[`simple 2`] = `
       Change
     </button>
     <p>
-      1
+      6
     </p>
     <p>
-      1
+      6
     </p>
   </div>
 </DocumentFragment>

--- a/src/__tests__/main.test.tsx
+++ b/src/__tests__/main.test.tsx
@@ -4,14 +4,14 @@ import { Component, FC, memo, useState } from "react";
 import * as testing from "@testing-library/react";
 
 test("simple", function() {
-  function useCounter() {
-    const [count, setCount] = useState(0);
+  function useCounter(initialValue: number) {
+    const [count, setCount] = useState(initialValue);
     const decrement = () => setCount(count - 1);
     const increment = () => setCount(count + 1);
     return { count, decrement, increment };
   }
 
-  const useCounterModel = createModel(useCounter);
+  const useCounterModel = createModel(useCounter, 5);
 
   const App: FC = () => {
     const counter = useCounterModel();

--- a/src/__tests__/main.test.tsx
+++ b/src/__tests__/main.test.tsx
@@ -2,16 +2,17 @@ import { createModel, withModel } from "..";
 import * as React from "react";
 import { Component, FC, memo, useState } from "react";
 import * as testing from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
 
 test("simple", function() {
-  function useCounter(initialValue: number) {
-    const [count, setCount] = useState(initialValue);
+  function useCounter() {
+    const [count, setCount] = useState(0);
     const decrement = () => setCount(count - 1);
     const increment = () => setCount(count + 1);
     return { count, decrement, increment };
   }
 
-  const useCounterModel = createModel(useCounter, 5);
+  const useCounterModel = createModel(useCounter);
 
   const App: FC = () => {
     const counter = useCounterModel();
@@ -28,6 +29,31 @@ test("simple", function() {
   expect(renderer.asFragment()).toMatchSnapshot();
   testing.fireEvent.click(testing.getByText(renderer.container, "Change"));
   expect(renderer.asFragment()).toMatchSnapshot();
+});
+
+test("createModel with arg", function() {
+  function useCounter(initalValue: number) {
+    const [count, setCount] = useState(initalValue);
+    const decrement = () => setCount(count - 1);
+    const increment = () => setCount(count + 1);
+    return { count, decrement, increment };
+  }
+
+  const useCounterModel = createModel(useCounter, 5);
+
+  const App: FC = () => {
+    const counter = useCounterModel();
+    return (
+      <div>
+        <button onClick={counter.increment}>Change</button>
+        <p>{counter.count}</p>
+      </div>
+    );
+  };
+  const { getByText, asFragment } = testing.render(<App />);
+  expect(asFragment()).toMatchSnapshot();
+  testing.fireEvent.click(getByText("Change"));
+  expect(asFragment()).toMatchSnapshot();
 });
 
 test("withModel", function() {

--- a/src/create-model.tsx
+++ b/src/create-model.tsx
@@ -4,7 +4,7 @@ import { Executor } from "./executor";
 import React, { useEffect, useRef, useState } from "react";
 import { render } from "./renderer";
 
-export function createModel<T, P>(hook: ModelHook<T, P>, hookProps?: P) {
+export function createModel<T, P>(hook: ModelHook<T, P>, hookArg?: P) {
   const container = new Container(hook);
   render(
     <Executor
@@ -12,7 +12,7 @@ export function createModel<T, P>(hook: ModelHook<T, P>, hookProps?: P) {
         container.data = val;
         container.notify();
       }}
-      hook={() => hook(hookProps)}
+      hook={() => hook(hookArg)}
     />
   );
   const useModel: UseModel<T> = depsFn => {

--- a/src/create-model.tsx
+++ b/src/create-model.tsx
@@ -4,7 +4,7 @@ import { Executor } from "./executor";
 import React, { useEffect, useRef, useState } from "react";
 import { render } from "./renderer";
 
-export function createModel<T>(hook: ModelHook<T>) {
+export function createModel<T, P>(hook: ModelHook<T, P>, hookProps?: P) {
   const container = new Container(hook);
   render(
     <Executor
@@ -12,7 +12,7 @@ export function createModel<T>(hook: ModelHook<T>) {
         container.data = val;
         container.notify();
       }}
-      hook={hook}
+      hook={() => hook(hookProps)}
     />
   );
   const useModel: UseModel<T> = depsFn => {

--- a/src/executor.tsx
+++ b/src/executor.tsx
@@ -2,7 +2,7 @@ import { ModelHook } from "./types";
 import { ReactElement } from "react";
 
 export function Executor<T>(props: {
-  hook: ModelHook<T>;
+  hook: () => ReturnType<ModelHook<T>>;
   onUpdate: (data: T) => void;
 }) {
   const data = props.hook();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type ModelHook<T = any, P = any> = (hookProps: P) => T;
+export type ModelHook<T = any, P = any> = (hookArg: P) => T;
 
 type Deps<T> = (model: T) => unknown[];
 export interface UseModel<T> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type ModelHook<T = any> = () => T;
+export type ModelHook<T = any, P = any> = (hookProps: P) => T;
 
 type Deps<T> = (model: T) => unknown[];
 export interface UseModel<T> {


### PR DESCRIPTION
We could pass a second parameter to createModel to set args for the custom hook.