### PR TITLE
fix: render twice when setState in async functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/react-reconciler": "^0.18.0",
-    "react-reconciler": "^0.25.1",
-    "use-action": "^1.0.2"
+    "react-reconciler": "^0.25.1"
   }
 }

--- a/src/__tests__/main.test.tsx
+++ b/src/__tests__/main.test.tsx
@@ -4,7 +4,6 @@ import { Component, FC, useEffect, useState } from "react";
 import * as testing from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import { act } from "react-dom/test-utils";
-import { useAction } from "use-action";
 import { usePersistFn } from "ahooks";
 import { createLazyModel } from "../create-model";
 
@@ -116,7 +115,7 @@ test("setState timing", async function() {
 
   const App: FC = () => {
     const counter = useCounterModel();
-    useAction(() => {
+    useEffect(() => {
       act(() => {
         useCounterModel.data.change();
       });

--- a/src/create-model.tsx
+++ b/src/create-model.tsx
@@ -3,7 +3,6 @@ import { Container } from "./container";
 import { Executor } from "./executor";
 import React, { useEffect, useRef, useState } from "react";
 import { render } from "./renderer";
-import { useAction } from "use-action";
 
 export function createModel<T, P>(hook: ModelHook<T, P>, hookArg?: P) {
   const container = new Container(hook);
@@ -26,7 +25,7 @@ export function createModel<T, P>(hook: ModelHook<T, P>, hookArg?: P) {
       depsFnRef.current?.(container.data) || []
     );
 
-    useAction(() => {
+    useEffect(() => {
       if (!container) return;
       function subscriber(val: T) {
         if (!depsFnRef.current) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5436,11 +5436,6 @@ urix@^0.1.0:
   resolved "https://registry.npm.taobao.org/urix/download/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-use-action@^1.0.2:
-  version "1.0.4"
-  resolved "https://registry.npm.taobao.org/use-action/download/use-action-1.0.4.tgz#51ef43d2977fcfecc6d9f66107e7d3594ddf6638"
-  integrity sha1-Ue9D0pd/z+zG2fZhB+fTWU3fZjg=
-
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.npm.taobao.org/use/download/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"


### PR DESCRIPTION
**问题：**

在异步函数内变更状态，会导致组件渲染两次，不符合预期。在一些异步取数据的长列表场景，重复渲染是不可接受的。

**复现路径：**

- `npx create-react-app hox-test`
- `cd hox-test`
- `npm i`
- `npm i hox@latest`
- 在`src/App.js`中编写如下的代码

```js
import React,{ useState, useCallback } from 'react';
import { createModel } from 'hox';

function useCounter(){
    const [ count, setCount ] = useState(0);

    const decrement = useCallback(() => {
        setTimeout(() => {
            setCount(count => count-1);
        }, 500);
    }, []);

    const increment = useCallback(() => setCount(count => count+1), []);

    return {
        count,
        decrement,
        increment
    }
}

const useCounterModel = createModel(useCounter);

function App() {
    const counter = useCounterModel();
    console.log('render');

    return (
        <div>
	        <button onClick={counter.decrement}>-</button>
	        <span>{counter.count}</span>
	        <button onClick={counter.increment}>+</button>
        </div>
    )
}

export default App;
```

- 启动项目，可以看到：点击减号的时候，render 会打印两次；点击加号的时候，render只会打印一次。


**原因及解决方法：**

- 初步定位是在`useCounterModel`初始化的时候，`container.subscribers.add(subscriber)` 执行了两次，添加了两个`subscriber`导致的
- 这也说明初始化的时候`useAction`判断有误，导致回调函数执行两次
- 将`useAction`替换成`useEffect`即可解决该问题
